### PR TITLE
fix(auth): align login fields and token naming

### DIFF
--- a/final-crm-backend/src/routes/auth.py
+++ b/final-crm-backend/src/routes/auth.py
@@ -53,11 +53,11 @@ def register():
         db.session.commit()
         
         # Create access token
-        access_token = create_access_token(identity=str(user.id))
+        token = create_access_token(identity=str(user.id))
         
         return jsonify({
             'message': 'Registration successful',
-            'access_token': access_token,
+            'token': token,
             'user': {
                 'id': user.id,
                 'username': user.username,
@@ -79,12 +79,13 @@ def login():
     try:
         data = request.get_json()
         
-        if not data.get('username') or not data.get('password'):
-            return jsonify({'error': 'Username and password required'}), 400
-        
+        login_id = data.get('email') or data.get('username')
+        if not login_id or not data.get('password'):
+            return jsonify({'error': 'Email/username and password required'}), 400
+
         # Find user by username or email
         user = User.query.filter(
-            (User.username == data['username']) | (User.email == data['username'])
+            (User.username == login_id) | (User.email == login_id)
         ).first()
         
         if not user or not user.check_password(data['password']):
@@ -98,11 +99,11 @@ def login():
         db.session.commit()
         
         # Create access token
-        access_token = create_access_token(identity=str(user.id))
+        token = create_access_token(identity=str(user.id))
         
         return jsonify({
             'message': 'Login successful',
-            'access_token': access_token,
+            'token': token,
             'user': {
                 'id': user.id,
                 'username': user.username,

--- a/final-crm-frontend/src/contexts/AuthContext.jsx
+++ b/final-crm-frontend/src/contexts/AuthContext.jsx
@@ -20,8 +20,9 @@ export function AuthProvider({ children }) {
     const token = localStorage.getItem('token')
     if (token) {
       // Verify token and get user info
-      api.get('/auth/me')
-        .then(response => {
+      api
+        .get('/auth/me')
+        .then((response) => {
           setUser(response.data.user)
         })
         .catch(() => {
@@ -38,17 +39,17 @@ export function AuthProvider({ children }) {
 
   const login = async (email, password) => {
     try {
-      const response = await api.post('/auth/login', { username: email, password })
+      const response = await api.post('/auth/login', { email, password })
       const { token, user: userData } = response.data
-      
+
       localStorage.setItem('token', token)
       setUser(userData)
-      
+
       return { success: true }
     } catch (error) {
-      return { 
-        success: false, 
-        error: error.response?.data?.error || 'Login failed' 
+      return {
+        success: false,
+        error: error.response?.data?.error || 'Login failed',
       }
     }
   }
@@ -57,15 +58,15 @@ export function AuthProvider({ children }) {
     try {
       const response = await api.post('/auth/register', userData)
       const { token, user: newUser } = response.data
-      
+
       localStorage.setItem('token', token)
       setUser(newUser)
-      
+
       return { success: true }
     } catch (error) {
-      return { 
-        success: false, 
-        error: error.response?.data?.error || 'Registration failed' 
+      return {
+        success: false,
+        error: error.response?.data?.error || 'Registration failed',
       }
     }
   }
@@ -76,22 +77,22 @@ export function AuthProvider({ children }) {
   }
 
   const updateUser = (userData) => {
-    setUser(prev => ({ ...prev, ...userData }))
+    setUser((prev) => ({ ...prev, ...userData }))
   }
 
   const hasPermission = (requiredRole) => {
     if (!user) return false
     if (user.role === 'admin') return true
-    
+
     const roleHierarchy = {
-      'admin': 5,
-      'manager': 4,
-      'sales': 3,
-      'technician': 2,
-      'financial': 2,
-      'user': 1
+      admin: 5,
+      manager: 4,
+      sales: 3,
+      technician: 2,
+      financial: 2,
+      user: 1,
     }
-    
+
     return roleHierarchy[user.role] >= roleHierarchy[requiredRole]
   }
 
@@ -102,13 +103,8 @@ export function AuthProvider({ children }) {
     register,
     logout,
     updateUser,
-    hasPermission
+    hasPermission,
   }
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
-  )
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
-


### PR DESCRIPTION
## Summary
- make backend login accept `email` or `username`
- return `token` key in auth responses
- adjust frontend AuthContext to send email during login

## Testing Done
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68665a1d53d8832f9e138d717f779772